### PR TITLE
expose WithMaxBufferedSpans()

### DIFF
--- a/lightstep/lightstep.go
+++ b/lightstep/lightstep.go
@@ -78,6 +78,15 @@ func WithPlainText(pt bool) Option {
 	}
 }
 
+// WithMaxBufferedSpans sets the maximum number of spans that will be buffered
+// before sending them to a collector.
+// Should be used to override the `DefaultMaxSpan` value of 1000.
+func WithMaxBufferedSpans(value int) Option {
+	return func(c *config) {
+		c.options.MaxBufferedSpans = value
+	}
+}
+
 // WithSystemMetricsDisabled determines if system metrics are disabled or not.
 // Default is false.
 func WithSystemMetricsDisabled(disabled bool) Option {


### PR DESCRIPTION
High volume services like permissions-api are overrunning this small buffer.  On guidance from Lightstep, they recommend raising this buffer where needed, which will involve exposing another TraceSetting