### PR TITLE
Remove overriding system metric endpoint

### DIFF
--- a/lightstep/lightstep.go
+++ b/lightstep/lightstep.go
@@ -33,7 +33,9 @@ func WithAccessToken(accessToken string) Option {
 func WithHost(host string) Option {
 	return func(c *config) {
 		c.options.Collector.Host = host
-		c.options.SystemMetrics.Endpoint.Host = host
+		// See https://invisionapp.atlassian.net/browse/ASC-553
+		// System metrics are not routed via the LightStep satellites
+		// c.options.SystemMetrics.Endpoint.Host = host
 	}
 }
 
@@ -41,7 +43,8 @@ func WithHost(host string) Option {
 func WithPort(port int) Option {
 	return func(c *config) {
 		c.options.Collector.Port = port
-		c.options.SystemMetrics.Endpoint.Port = port
+		// System metrics are not routed via the LightStep satellites
+		// c.options.SystemMetrics.Endpoint.Port = port
 	}
 }
 

--- a/lightstep/lightstep_test.go
+++ b/lightstep/lightstep_test.go
@@ -136,7 +136,8 @@ func TestWithHost(t *testing.T) {
 	)
 
 	assert.EqualValues(host, config.options.Collector.Host)
-	assert.EqualValues(host, config.options.SystemMetrics.Endpoint.Host)
+	// System metrics are not routed via the LightStep satellites
+	// assert.EqualValues(host, config.options.SystemMetrics.Endpoint.Host)
 }
 
 func TestWithPort(t *testing.T) {
@@ -148,7 +149,8 @@ func TestWithPort(t *testing.T) {
 	)
 
 	assert.EqualValues(port, config.options.Collector.Port)
-	assert.EqualValues(port, config.options.SystemMetrics.Endpoint.Port)
+	// System metrics are not routed via the LightStep satellites
+	// assert.EqualValues(port, config.options.SystemMetrics.Endpoint.Port)
 }
 
 func TestWithAccessToken(t *testing.T) {


### PR DESCRIPTION
...so that the default stored within lightstep-tracer-go is always used.

Fixes https://invisionapp.atlassian.net/browse/ASC-553
